### PR TITLE
PDK_STRUCTURE.md: fix typo.

### DIFF
--- a/doc/PDK_STRUCTURE.md
+++ b/doc/PDK_STRUCTURE.md
@@ -83,7 +83,7 @@ This section defines the necessary variables to configure a standard cell librar
 | `FILL_CELL` | Defines the fill cell. Used in fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
 | `DECAP_CELL` | Defines the decap cell used for fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
 | `CELL_PAD` | Defines the number of sites to pad the cells lef views with. |
-| `CELL_PAD_EXECLUDE` | Defines the cells to exclude from padding. |
+| `CELL_PAD_EXCLUDE` | Defines the cells to exclude from padding. |
 | `CTS_ROOT_BUFFER` | Defines the cell inserted at the root of the clock tree. Used in CTS. |
 | `CLK_BUFFER` | Defines the clock buffer cell. Used in CTS. |
 | `CLK_BUFFER_INPUT` | Defines the clock buffer cell input port. Used in CTS. |


### PR DESCRIPTION
The wrong name has been deprecated.