### PR TITLE
Spef_extract: remove dependency on matplotlib and numpy

### DIFF
--- a/scripts/spef_extractor/README.md
+++ b/scripts/spef_extractor/README.md
@@ -4,19 +4,6 @@ A Python library that reads LEF and DEF files, extracts the RC parasitics and ge
 ## Dependancies:  
   In order to parse the lef and def files, we used [trimcao's def and lef parser](https://github.com/trimcao/lef-parser)
 
-## Build Instructions:
-   To install the library run the following commands: 
-   ```
-   
-   pip install numpy
-   
-   pip install sympy
-  
-   pip install matplotlib   
-   
-   git clone https://github.com/Cloud-V/SPEF_EXTRACTOR/
-   ```
-
 ## Using the library
 In order to use the project, use the terminal to run `main.py` using the following format.<br />
 `python3 main.py -l <lef_file_path> -d <def_file_path> -wm <wire_model which can be L or Pi> -ec <edge_capacitance_factor which is a value between 0 and 1 where the default is 1> [-r <root_directory from which you are running the code>]` <br />

--- a/scripts/spef_extractor/lef_def_parser/cell_learn.py
+++ b/scripts/spef_extractor/lef_def_parser/cell_learn.py
@@ -105,6 +105,13 @@ def merge_data(data_folder, num_cells):
     return dataset
 
 
+def randomize(dataset, labels):
+    permutation = np.random.permutation(labels.shape[0])
+    shuffled_dataset = dataset[permutation, :]
+    shuffled_labels = labels[permutation]
+    return shuffled_dataset, shuffled_labels
+
+
 def train_model(dataset, data_len, num_to_label):
     """
     Method to train model
@@ -131,7 +138,7 @@ def train_model(dataset, data_len, num_to_label):
 
     # shuffle the dataset
     random.seed(6789)
-    all_dataset, all_label = util.randomize(all_dataset, all_label)
+    all_dataset, all_label = randomize(all_dataset, all_label)
     num_train = int(0.85 * data_len)
 
     #print(max(all_label))

--- a/scripts/spef_extractor/lef_def_parser/draw_util.py
+++ b/scripts/spef_extractor/lef_def_parser/draw_util.py
@@ -1,0 +1,108 @@
+"""
+Useful functions for DEF/LEF parsers.
+Author: Tri Minh Cao
+Email: tricao@utdallas.edu
+Date: August 2016
+"""
+
+SCALE = 2000
+import matplotlib.pyplot as plt
+import numpy as np
+import math
+
+
+def draw_obs(obs, color):
+    """
+    Helper method to draw a OBS object
+    :return: void
+    """
+    # process each Layer
+    for layer in obs.info["LAYER"]:
+        for shape in layer.shapes:
+            scaled_pts = scalePts(shape.points, SCALE)
+            if (shape.type == "RECT"):
+                scaled_pts = rect_to_polygon(scaled_pts)
+            draw_shape = plt.Polygon(scaled_pts, closed=True, fill=True,
+                                     color=color)
+            plt.gca().add_patch(draw_shape)
+
+
+def draw_port(port, color):
+    """
+    Helper method to draw a PORT object
+    :return: void
+    """
+    # process each Layer
+    for layer in port.info["LAYER"]:
+        for shape in layer.shapes:
+            scaled_pts = scalePts(shape.points, SCALE)
+            if (shape.type == "RECT"):
+                scaled_pts = rect_to_polygon(scaled_pts)
+            #print (scaled_pts)
+            draw_shape = plt.Polygon(scaled_pts, closed=True, fill=True,
+                                     color=color)
+            plt.gca().add_patch(draw_shape)
+
+
+def draw_pin(pin):
+    """
+    function to draw a PIN object
+    :param pin: a pin object
+    :return: void
+    """
+    # chosen color of the PIN in the sketch
+
+    color = "blue"
+    pin_name = pin.name.lower()
+    if pin_name == "vdd" or pin_name == "gnd":
+        color = "blue"
+    else:
+        color = "red"
+    draw_port(pin.info["PORT"], color)
+
+def draw_macro(macro):
+    """
+    function to draw a Macro (cell) object
+    :param macro: a Macro object
+    :return: void
+    """
+    # draw OBS (if it exists)
+    if "OBS" in macro.info:
+        draw_obs(macro.info["OBS"], "blue")
+    # draw each PIN
+    for pin in macro.info["PIN"]:
+        draw_pin(pin)
+
+def draw_cells():
+    """
+    code to draw cells based on LEF information.
+    :return: void
+    """
+    to_draw = []
+    to_draw.append(input("Enter the first macro: "))
+    to_draw.append(input("Enter the second macro: "))
+    #to_draw = ["AND2X1", "AND2X2"]
+
+
+    plt.figure(figsize=(12, 9), dpi=80)
+    plt.axes()
+
+    num_plot = 1
+    for macro_name in to_draw:
+        # check user's input
+        if macro_name not in lef_parser.macro_dict:
+            print ("Error: This macro does not exist in the parsed library.")
+            quit()
+        macro = lef_parser.macro_dict[macro_name]
+        sub = plt.subplot(1, 2, num_plot)
+        # need to add title
+        sub.set_title(macro.name)
+        draw_macro(macro)
+        num_plot += 1
+        # scale the axis of the subplot
+        plt.axis('scaled')
+
+
+    # start drawing
+    print ("Start drawing...")
+    plt.show()

--- a/scripts/spef_extractor/lef_def_parser/lef_parser.py
+++ b/scripts/spef_extractor/lef_def_parser/lef_parser.py
@@ -106,40 +106,6 @@ class LefParser:
         print ("Parsing LEF file done.")
 
 
-def draw_cells():
-    """
-    code to draw cells based on LEF information.
-    :return: void
-    """
-    to_draw = []
-    to_draw.append(input("Enter the first macro: "))
-    to_draw.append(input("Enter the second macro: "))
-    #to_draw = ["AND2X1", "AND2X2"]
-
-
-    plt.figure(figsize=(12, 9), dpi=80)
-    plt.axes()
-
-    num_plot = 1
-    for macro_name in to_draw:
-        # check user's input
-        if macro_name not in lef_parser.macro_dict:
-            print ("Error: This macro does not exist in the parsed library.")
-            quit()
-        macro = lef_parser.macro_dict[macro_name]
-        sub = plt.subplot(1, 2, num_plot)
-        # need to add title
-        sub.set_title(macro.name)
-        draw_macro(macro)
-        num_plot += 1
-        # scale the axis of the subplot
-        plt.axis('scaled')
-
-
-    # start drawing
-    print ("Start drawing...")
-    plt.show()
-
 """
 # Main Class
 if __name__ == '__main__':

--- a/scripts/spef_extractor/lef_def_parser/util.py
+++ b/scripts/spef_extractor/lef_def_parser/util.py
@@ -28,8 +28,6 @@ Date: August 2016
 """
 
 SCALE = 2000
-import matplotlib.pyplot as plt
-import numpy as np
 import math
 
 
@@ -124,69 +122,6 @@ def split_space(line):
     """
     new_line = line.split()
     return new_line
-
-
-def draw_obs(obs, color):
-    """
-    Helper method to draw a OBS object
-    :return: void
-    """
-    # process each Layer
-    for layer in obs.info["LAYER"]:
-        for shape in layer.shapes:
-            scaled_pts = scalePts(shape.points, SCALE)
-            if (shape.type == "RECT"):
-                scaled_pts = rect_to_polygon(scaled_pts)
-            draw_shape = plt.Polygon(scaled_pts, closed=True, fill=True,
-                                     color=color)
-            plt.gca().add_patch(draw_shape)
-
-
-def draw_port(port, color):
-    """
-    Helper method to draw a PORT object
-    :return: void
-    """
-    # process each Layer
-    for layer in port.info["LAYER"]:
-        for shape in layer.shapes:
-            scaled_pts = scalePts(shape.points, SCALE)
-            if (shape.type == "RECT"):
-                scaled_pts = rect_to_polygon(scaled_pts)
-            #print (scaled_pts)
-            draw_shape = plt.Polygon(scaled_pts, closed=True, fill=True,
-                                     color=color)
-            plt.gca().add_patch(draw_shape)
-
-
-def draw_pin(pin):
-    """
-    function to draw a PIN object
-    :param pin: a pin object
-    :return: void
-    """
-    # chosen color of the PIN in the sketch
-
-    color = "blue"
-    pin_name = pin.name.lower()
-    if pin_name == "vdd" or pin_name == "gnd":
-        color = "blue"
-    else:
-        color = "red"
-    draw_port(pin.info["PORT"], color)
-
-def draw_macro(macro):
-    """
-    function to draw a Macro (cell) object
-    :param macro: a Macro object
-    :return: void
-    """
-    # draw OBS (if it exists)
-    if "OBS" in macro.info:
-        draw_obs(macro.info["OBS"], "blue")
-    # draw each PIN
-    for pin in macro.info["PIN"]:
-        draw_pin(pin)
 
 def compare_metal(metal_a, metal_b):
     """
@@ -360,13 +295,6 @@ def sort_vias_by_row(layout_area, row_height, vias):
     for each_row in rows:
         each_row.sort(key = lambda x: x[0][0])
     return rows
-
-
-def randomize(dataset, labels):
-    permutation = np.random.permutation(labels.shape[0])
-    shuffled_dataset = dataset[permutation, :]
-    shuffled_labels = labels[permutation]
-    return shuffled_dataset, shuffled_labels
 
 
 def group_via(via_list, max_number, max_distance):

--- a/scripts/spef_extractor/main.py
+++ b/scripts/spef_extractor/main.py
@@ -52,7 +52,6 @@ args = parser.parse_args()
 
 p = args.root_dir
 sys.path.insert(0, str(p)+'/scripts/spef_extractor/lef_def_parser')
-import matplotlib as plt
 from def_parser import *
 from lef_parser import *
 import codecs


### PR DESCRIPTION
Although both matplotlib and numpy are widely used, they aren't used by spef_extractor.  So no need to depend on them.