### PR TITLE
spef_extract: remove character replacements

### DIFF
--- a/scripts/spef_extractor/main.py
+++ b/scripts/spef_extractor/main.py
@@ -767,12 +767,4 @@ printNameMap(map_of_names)
 printSPEFNets(netsDict)  
 f.close()
 
-
-content = open(str(def_file_name[:-4]) + ".spef", "r+").read()
-newContent = content.replace('<', '[')
-newContent = newContent.replace('>', ']')
-
-f =  open(str(def_file_name[:-4]) + ".spef","w+", newline='\n')
-f.write(newContent)
-
 print("Writing SPEF is done")

--- a/scripts/spef_extractor/main.py
+++ b/scripts/spef_extractor/main.py
@@ -760,7 +760,7 @@ maxCapNet = ["*0"]
 minCap = [1]
 minCapNet = ["*0"]
 
-f = open(str(def_file_name[:-4]) + ".spef","w+", newline='\n')
+f = open(str(def_file_name[:-4]) + ".spef", "w", newline='\n')
 print("Start writing SPEF file")
 printSPEFHeader()
 printNameMap(map_of_names)


### PR DESCRIPTION
The SPEF file is written once, and then read and rewritten to replace '<' and '>' with '[' and '].
But this is not needed as '[' and ']' are already used for vectors in the DEF file.
