### PR TITLE
spef_extract: simplify imports

### DIFF
--- a/scripts/spef_extractor/lef_def_parser/def_parser.py
+++ b/scripts/spef_extractor/lef_def_parser/def_parser.py
@@ -27,8 +27,8 @@ Email: tricao@utdallas.edu
 Date: August 2016
 """
 
-from def_util import *
-from util import *
+from .def_util import *
+from .util import *
 
 
 class DefParser:

--- a/scripts/spef_extractor/lef_def_parser/def_util.py
+++ b/scripts/spef_extractor/lef_def_parser/def_util.py
@@ -26,7 +26,7 @@ Author: Tri Minh Cao
 Email: tricao@utdallas.edu
 Date: August 2016
 """
-from util import *
+from .util import *
 
 class Pins:
     """

--- a/scripts/spef_extractor/lef_def_parser/lef_parser.py
+++ b/scripts/spef_extractor/lef_def_parser/lef_parser.py
@@ -26,8 +26,8 @@ Author: Tri Cao
 Email: tricao@utdallas.edu
 Date: August 2016
 """
-from lef_util import *
-from util import *
+from .lef_util import *
+from .util import *
 
 SCALE = 2000
 

--- a/scripts/spef_extractor/lef_def_parser/lef_util.py
+++ b/scripts/spef_extractor/lef_def_parser/lef_util.py
@@ -26,7 +26,7 @@ Author: Tri Minh Cao
 Email: tricao@utdallas.edu
 Date: August 2016
 """
-from util import *
+from .util import *
 
 class Statement:
     """

--- a/scripts/spef_extractor/main.py
+++ b/scripts/spef_extractor/main.py
@@ -52,10 +52,8 @@ args = parser.parse_args()
 
 p = args.root_dir
 sys.path.insert(0, str(p)+'/scripts/spef_extractor/lef_def_parser')
-from def_parser import *
-from lef_parser import *
-import codecs
-from collections import defaultdict
+from def_parser import DefParser
+from lef_parser import LefParser
 import datetime
 import os
 #in order to print Date in the SPEF file

--- a/scripts/spef_extractor/main.py
+++ b/scripts/spef_extractor/main.py
@@ -29,18 +29,23 @@ Authors:
 import sys
 import pathlib
 import argparse
+import datetime
+import os
+from lef_def_parser.def_parser import DefParser
+from lef_def_parser.lef_parser import LefParser
+
+#in order to print Date in the SPEF file
+now = datetime.datetime.now()
+
 
 parser = argparse.ArgumentParser(
-    description='Creates and obstruction in def and lef files.')
+    description='Create a parasitic SPEF file from def and lef files.')
 
 parser.add_argument('--def_file', '-d',required=True,
                     help='Input DEF')
 
 parser.add_argument('--lef_file', '-l',required=True,
                    help='Input LEF')
-
-parser.add_argument('--root_dir', '-r',default=pathlib.Path('.'),required=False,
-                   help='root directory')
 
 parser.add_argument('--wire_model', '-mw', default='PI',required=False,
                     help='name of wire model')
@@ -49,15 +54,6 @@ parser.add_argument('--edge_cap_factor', '-ec', default=1,required=False,
                     help='Edge Capacitance Factor 0 to 1')
 
 args = parser.parse_args()
-
-p = args.root_dir
-sys.path.insert(0, str(p)+'/scripts/spef_extractor/lef_def_parser')
-from def_parser import DefParser
-from lef_parser import LefParser
-import datetime
-import os
-#in order to print Date in the SPEF file
-now = datetime.datetime.now()
 
 
 

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -225,7 +225,7 @@ proc ins_diode_cells {args} {
 
 proc run_spef_extraction {args} {
     if { $::env(RUN_SPEF_EXTRACTION) == 1 } {
-        try_catch python3 $::env(SCRIPTS_DIR)/spef_extractor/main.py -l $::env(MERGED_LEF_UNPADDED) -d $::env(CURRENT_DEF) -mw $::env(SPEF_WIRE_MODEL) -ec $::env(SPEF_EDGE_CAP_FACTOR) -r $::env(OPENLANE_ROOT) |& tee $::env(TERMINAL_OUTPUT) $::env(LOG_DIR)/routing/spef_extraction.log
+        try_catch python3 $::env(SCRIPTS_DIR)/spef_extractor/main.py -l $::env(MERGED_LEF_UNPADDED) -d $::env(CURRENT_DEF) -mw $::env(SPEF_WIRE_MODEL) -ec $::env(SPEF_EDGE_CAP_FACTOR) |& tee $::env(TERMINAL_OUTPUT) $::env(LOG_DIR)/routing/spef_extraction.log
         set ::env(CURRENT_SPEF) [file rootname $::env(CURRENT_DEF)].spef
         #puts $fbasename
         #set ::env(CURRENT_SPEF) 


### PR DESCRIPTION
Use relative import statements instead of modifying the module path from an argument.
This simplifies the code and also allows to group all the imports at the beginning of the file.

Also remove unused import and fix the description of the tool.