### PR TITLE
scripts/libtrim.pl: Don't warn on experimental

### DIFF
--- a/scripts/libtrim.pl
+++ b/scripts/libtrim.pl
@@ -21,6 +21,8 @@ use strict;
 use feature "switch";
 #use experimental qw( switch );
 
+no warnings 'experimental';
+
 open (LIB, $ARGV[0]) or die("Couldn't open $ARGV[0]");
 open (CELLS,'<', $ARGV[1]) or die("Couldn't open $ARGV[1]");
 


### PR DESCRIPTION
Ubuntu uses a perl version that throws a warning. This doesn't stop it
from running but the stderr output is interpreted as an error by the flow
and stopping it. So disable those warnings.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>