### PR TITLE
Supress errors from openROAD about missing config files

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -69,6 +69,9 @@ ADD ./openroad_tools.tar.gz /
 COPY ./.tclshrc /
 COPY ./.tclshrc /root
 
+RUN touch /.sta
+RUN touch /.openroad
+
 ADD ./openLANE_flow.tar.gz $OPENLANE_ROOT
 
 # install opendb python


### PR DESCRIPTION
openROAD complains about those config files missing when running sta and openroad, adding them empty removes those confusing errors.