### PR TITLE
Add wget to docker image

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -41,6 +41,7 @@ RUN yum install -y https://repo.ius.io/ius-release-el$(rpm -E '%{rhel}').rpm && 
 		tcl \
 		tcllib \
 		tk \
+		wget \
 		Xvfb && \
 	yum clean all && \
 	rm -rf /var/cache/yum


### PR DESCRIPTION
The caravel instructions suggest using the openlane docker container
to install the pdks. That process needs wget, which isn't currently
in the image. Add it.