### PR TITLE
Sphinx + ReadTheDocs (develop)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: conf.py
+
+conda:
+  environment: docs/environment.yml

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,150 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+# sys.path.insert(0, os.path.abspath('.'))
+from recommonmark.parser import CommonMarkParser
+sys.path.insert(0, os.path.abspath('docs/_ext'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'OpenLANE'
+copyright = '2020, efabless'
+author = 'efabless'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+  'sphinx.ext.todo',
+  'markdown_code_links',
+  'markdown_cross_doc_section_links',
+  'sphinx.ext.autosectionlabel',
+  'sphinx_markdown_tables',
+  'image_links',
+  'toc_from_markdown',
+  'recommonmark',
+]
+
+# Expand source suffixes
+
+source_parsers = {
+    '.md': CommonMarkParser,
+}
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md' : 'markdown',
+}
+
+
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    # Files included in other rst files.
+]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_symbiflow_theme'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#
+html_theme_options = {
+    # Specify a list of menu in Header.
+    # Tuples forms:
+    #  ('Name', 'external url or path of pages in the document', boolean, 'icon name')
+    #
+    # Third argument:
+    # True indicates an external link.
+    # False indicates path of pages in the document.
+    #
+    # Fourth argument:
+    # Specify the icon name.
+    # For details see link.
+    # https://material.io/icons/
+    'header_links': [
+        ('Home', 'index', False, 'home'),
+        ("GitHub", "https://github.com/efabless/openlane", True, 'code'),
+        ("efabless", "https://www.efabless.com/", True, 'link'),
+    ],
+
+    # Customize css colors.
+    # For details see link.
+    # https://getmdl.io/customize/index.html
+    #
+    # Values: amber, blue, brown, cyan deep_orange, deep_purple, green, grey, indigo, light_blue,
+    #         light_green, lime, orange, pink, purple, red, teal, yellow(Default: indigo)
+    'primary_color': 'deep_purple',
+    # Values: Same as primary_color. (Default: pink)
+    'accent_color': 'teal',
+
+    # Customize layout.
+    # For details see link.
+    # https://getmdl.io/components/index.html#layout-section
+    'fixed_drawer': True,
+    'fixed_header': True,
+    'header_waterfall': True,
+    'header_scroll': False,
+
+    # Render title in header.
+    # Values: True, False (Default: False)
+    'show_header_title': False,
+    # Render title in drawer.
+    # Values: True, False (Default: True)
+    'show_drawer_title': True,
+    # Render footer.
+    # Values: True, False (Default: True)
+    'show_footer': True,
+
+    # Hide the symbiflow links
+    'hide_symbiflow_links': True,
+    'license_url' : 'https://www.apache.org/licenses/LICENSE-2.0',
+}
+
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['docs/_static']
+
+todo_include_todos = True
+numfig = True
+markdown_code_links_githubrepo   = 'https://github.com/efabless/openlane'
+markdown_code_links_githubbranch = 'blob/master'
+markdown_code_links_codefileextensions = ['.tcl', '.sh', '.cfg', '.gds', '/', '.json', 'Makefile']
+autosectionlabel_prefix_document = True
+
+suppress_warnings = ['misc.highlighting_failure'] # supress json highlight warnings
+
+def setup(app):
+    app.emit('create_index_softlink', 'README.md', True)
+    app.emit('toc_from_markdown', 'README.md', '.autotoc.rst', True)
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = ..
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_ext/image_links.py
+++ b/docs/_ext/image_links.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+def setup(app):
+    app.connect('source-read', process_image_links)
+    return {'version': '1.0',
+            'parallel_read_safe': True}
+
+def process_image_links(app, docname, source):
+    """
+    Converts image links in markdown files
+    from ./..../imagename.png to _static/imagename.png 
+    This function is called by sphinx for each document. 
+    `source` is a 1-item list. 
+    """
+
+    linkexp = '<img src=\".*\"\s*>'
+    
+    for m in re.finditer(linkexp,source[0]):
+            print (f" IMAGE_LINKS {docname}")
+            link = m.group(0).split('"')
+            if len(link)==3 and link[1].startswith('.'):
+                link[1] = '_static/' + link[1].rpartition('/')[2]
+                link    = '"'.join(link)
+                print (f" {docname}: img link: {link}")
+                
+                source[0] = source[0][:m.start()] + link + source[0][m.end():]
+

--- a/docs/_ext/markdown_code_links.py
+++ b/docs/_ext/markdown_code_links.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+import os
+import os.path as path
+
+def setup(app):
+    app.add_config_value('markdown_code_links_githubrepo', 'https://github.com/name/repo', 'html')
+    app.add_config_value('markdown_code_links_githubbranch', 'blob/master', 'html')
+    app.add_config_value('markdown_code_links_codefileextensions', ['.c','.cpp'], 'html')
+    app.connect('source-read', process_image_links)
+    return {'version': '1.0',
+            'parallel_read_safe': False}
+
+
+def local_link_to_github (link, docname, githublink):
+    # get source document dir
+    path = docname.rpartition('/')[0]
+    # remove './'
+    if link.startswith('./'):
+       link = link[2:]
+    # move up if necessary
+    while link.startswith('../'):
+       link = link.partition('/')[2]
+       path = path.rpartition('/')[0]
+    # combine with repo path
+    if len(path): 
+       link = path.rstrip('/') + '/' + link.lstrip('/')
+    # combine with repo link
+    link = githublink.rstrip('/') + '/' + link.lstrip('/')
+    return link
+    
+def printv (verb, lvl, arg):
+    ''' Print depending on verbose level '''
+    if verb >= lvl: print (arg)
+
+def process_image_links(app, docname, source):
+    """
+    Converts local code links (specific file types) in markdown files
+    to github links to the same repo
+    from: [link_name](./dir1/dir2.../file.ext)
+    to:   [link_name(https:gihtub.com/repo/dir1/dir2.../file.ext)
+    This function is called by sphinx for each document. 
+    `source` is a 1-item list. 
+    """
+    verb = 1 # verbosity level (debug)
+
+    githublink          =  app.config.markdown_code_links_githubrepo.rstrip('/') + '/'
+    githublink          += app.config.markdown_code_links_githubbranch.rstrip('/')
+    codefileextensions  =  app.config.markdown_code_links_codefileextensions
+    fulldocname         = path.join (app.srcdir, docname)
+    fulldocdir          = path.dirname (fulldocname)
+
+    # case 1 [name](./dir/file) or [name](../dir/file)
+    linknameexp1    = '\[[\/\.\w]*\]'
+    linktargetexp1  = '\(\.[\/\.\w]*{fileext}\)'
+
+    # case 2 [tag] 
+    linknameexp2    = '\[[0-9]*\]\:\s*'
+    linktargetexp2  = '\.[\/\.\w]*{fileext}\s*\n'
+
+    # directory links don't need to end with '/', but will be verified as dirs
+    if '/' in codefileextensions:
+        codefileextensions.append('')
+
+    for fileext in codefileextensions:
+        if fileext.startswith('.') or fileext.startswith('/'):
+            fileext = '\\' + fileext
+
+        linkexp = linknameexp1 + linktargetexp1.format(fileext=fileext)
+        for m in reversed(list( re.finditer( linkexp, source[0]) )):
+                printv (verb, 1, f"Code link conv {docname} : {m.group(0)}")
+                # strip link
+                link = m.group(0).partition('(')[2].rpartition(')')[0]
+                # dirs require verification
+                if fileext not in ('\\/', '') or path.isdir(path.join(fulldocdir,link)):
+                    link = local_link_to_github (link, docname, githublink)
+                    # combine with rest of markdown link
+                    link = m.group(0).partition('(')[0] + '(' + link + ')'
+                    printv (verb, 2, link)
+                    source[0] = source[0][:m.start()] + link + source[0][m.end():]
+
+        linkexp = linknameexp2 + linktargetexp2.format(fileext=fileext)
+        for m in reversed(list( re.finditer(linkexp, source[0]) )):
+                printv (verb, 1, f"Code link conv {docname} : {m.group(0).strip()}")
+                # strip link
+                link = m.group(0).rpartition(':')[2].strip()
+                # dirs require verification
+                if fileext not in ('\\/', '') or path.isdir(path.join(fulldocdir,link)):
+                    link = local_link_to_github (link, docname, githublink)
+                    # combine with rest of markdown link
+                    link = m.group(0).partition(':')[0] + ': ' + link
+                    printv (verb, 2, link)
+                    source[0] = source[0][:m.start()] + link + source[0][m.end():]
+

--- a/docs/_ext/markdown_code_links.py
+++ b/docs/_ext/markdown_code_links.py
@@ -104,7 +104,7 @@ def process_image_links(app, docname, source):
                 if fileext not in ('\\/', '') or path.isdir(path.join(fulldocdir,link)):
                     link = local_link_to_github (link, docname, githublink)
                     # combine with rest of markdown link
-                    link = m.group(0).partition(':')[0] + ': ' + link
+                    link = m.group(0).partition(':')[0] + ': ' + link.strip() + '\n'
                     printv (verb, 2, link)
                     source[0] = source[0][:m.start()] + link + source[0][m.end():]
 

--- a/docs/_ext/markdown_cross_doc_section_links.py
+++ b/docs/_ext/markdown_cross_doc_section_links.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+def setup(app):
+    app.connect('source-read', process_markdown_crosslinks)
+    return {'version': '1.0',
+            'parallel_read_safe': True}
+
+def process_markdown_crosslinks(app, docname, source):
+    """
+    Converts markdown links to another doc's section:
+        [link name](./path/doc.md#section)
+    which are not supported by recommonmark
+    to a format recognized by autosectionlabel:
+        [link name](<path/doc:section>)
+    Requires:
+      recommonmark
+      sphinx.ext.autosectionlabel
+      autosectionlabel_prefix_document = True 
+    """
+
+    # MD cross-section tag [tag](./dir/file.md#section)
+    linknameexp    = '\[[\/\.\w]*\]'
+    linktargetexp  = '\(\.[\/\.\w]*\.md#\w*\)'
+    linkexp = linknameexp + linktargetexp
+
+    for m in reversed(list( re.finditer(linkexp, source[0]) )):
+       link = m.group(0)
+       link = link.replace ('(./','(')   # remove './' if present
+       link = link.replace ('(','(<')    # change parenthesis
+       link = link.replace (')','>)')    # change parenthesis
+       link = link.replace ('.md#',':')  # change section symbol
+       print (f"Cross doc link conv {docname} : {m.group(0)} to {link}")
+       source[0] = source[0][:m.start()] + link + source[0][m.end():]
+

--- a/docs/_ext/toc_from_markdown.py
+++ b/docs/_ext/toc_from_markdown.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re 
+import os
+import os.path as path
+
+cleanup_on_finish_files = []
+
+def setup(app):
+    app.add_event("create_index_softlink")
+    app.connect('create_index_softlink', index_softlink)
+    app.add_event("toc_from_markdown")
+    app.connect('toc_from_markdown', auto_generate_toc)
+    app.connect('build-finished', after_build_cleanup)
+    return {'version': '1.0',
+            'parallel_read_safe': True}
+
+def after_build_cleanup (app, exception):
+    for f in cleanup_on_finish_files:
+        os.remove (path.join (app.srcdir, f))
+        print (f'Deleted {f}')
+ 
+def extract_markdown_links (file):
+    ''' Extracts list of local markdown links from markdown file'''
+    # two formats for local markdown file links
+    linknameexp1    = '\[[\/\.\w]*\]'
+    linktargetexp1  = '\(\.[\/\.\w]*{fileext}\)'
+    linkexp1        = linknameexp1 + linktargetexp1.format(fileext='\.md')
+
+    # case 2 [tag] link 
+    linknameexp2    = '\[[0-9]*\]\:\s*'
+    linktargetexp2  = '\.[\/\.\w]*{fileext}\s*\n'
+    linkexp2       = linknameexp2 + linktargetexp2.format(fileext='\.md')
+
+    links =[]
+    try:
+       with open (file,'r') as f:
+          block = f.read()
+          for m in re.finditer( linkexp1, block ):
+            link = m.group(0).partition('(')[2].rpartition(')')[0].strip()
+            links.append (link)
+          for m in re.finditer( linkexp2, block ):
+             link = m.group(0).rpartition(':')[2].strip()
+             links.append (link)
+    except:
+          print (f"Warning: Cannot process {file}")
+
+    return links
+
+def auto_generate_toc (app, master, tocname, cleanup = False, hidden = True, maxdepth=3):
+    """
+    Automaticaly generate rst file with hidden toc'
+    """
+    global cleanup_on_finish_files
+
+    if cleanup:
+       cleanup_on_finish_files.append(tocname)
+
+    master  = path.join (app.srcdir, master)
+    tocname = path.join (app.srcdir, path.basename (tocname))
+    links = [master]
+
+    while maxdepth:
+        newlinks = []
+        for file in links:
+            fromfile = extract_markdown_links(file)
+            newlinks += [ path.normpath( path.join (os.path.dirname(file),l)) for l in fromfile ]
+        newlinks = [ l for l in set(newlinks) if l not in links ]
+        if not len( newlinks ):
+            break
+        links += newlinks
+        maxdepth -= 1
+
+    links = [ os.path.relpath(l, os.path.dirname(tocname)) for l in links ]
+    links.sort()
+
+    with open (tocname,'w') as f:
+        indent = '   '
+        f.write (':orphan:\n\n')
+        f.write ('.. toctree::\n')
+        if (hidden): 
+            f.write( indent + ':hidden:\n' )
+        f.write('\n')
+        for l in links:
+            f.write( indent + l + '\n' )
+
+def index_softlink (app, master, cleanup = False):
+    global cleanup_on_finish_files
+
+    softlink = 'index.' + master.rpartition('.')[2] 
+    if cleanup:
+       cleanup_on_finish_files.append(softlink)
+
+    master  = path.join (app.srcdir, master)
+    softlink = path.join (app.srcdir, softlink)
+
+    try:
+        os.symlink (master, softlink)
+    except FileExistsError:
+        os.remove  (softlink)
+        os.symlink (master, softlink)
+    
+       
+        
+

--- a/docs/_static/openlane.flow.1.png
+++ b/docs/_static/openlane.flow.1.png
@@ -1,0 +1,1 @@
+../../doc/openlane.flow.1.png

--- a/docs/_static/striVe.jpeg
+++ b/docs/_static/striVe.jpeg
@@ -1,0 +1,1 @@
+../../doc/striVe.jpeg

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,7 @@
+name: caravel-docs
+channels:
+- defaults
+dependencies:
+- python>=3.8
+- pip:
+  - -r file:requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+git+https://github.com/SymbiFlow/sphinx_materialdesign_theme.git#egg=sphinx-symbiflow-theme
+
+docutils
+sphinx
+sphinx-autobuild
+recommonmark
+sphinx_markdown_tables


### PR DESCRIPTION
This PR introduces Sphinx and ReadTheDocs setup for current markdown documentation.
It it a clean re-submit of https://github.com/efabless/openlane/pull/134 for `develop` branch

Preview is available here:
https://openlane-docs.readthedocs.io/en/rtd-develop/
