### PR TITLE
Move add_route_obs before global routing

### DIFF
--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -253,6 +253,8 @@ proc run_routing {args} {
     }
     use_original_lefs
 
+    add_route_obs
+
     global_routing
 
     # insert fill_cells
@@ -267,7 +269,6 @@ proc run_routing {args} {
 
 
     # detailed routing
-    add_route_obs
     detailed_routing
 
 	# pdngen-related hack


### PR DESCRIPTION
On a design with many large macros, FastRoute is placing guides right
through the middle of those macros. TritonRoute never manages to recover
from this and I end up with over a thousand DRC issues due to these tracks.

In order to stop this I added an GLB_RT_OBS line covering all the macros,
but that didn't help FastRoute because the obstructions get added after global
routing. Moving add_route_obs earlier fixes this.