### PR TITLE
Build netgen with optimisation

### DIFF
--- a/docker_build/docker/netgen/Dockerfile
+++ b/docker_build/docker/netgen/Dockerfile
@@ -32,7 +32,7 @@ RUN git checkout 920c6e69283f9bef5d3aa67776b868696e438c2d
 
 
 # build
-RUN ./configure --prefix=/build
+RUN ./configure CFLAGS="-O2 -g" --prefix=/build
 
 RUN make clean && \
     make && \


### PR DESCRIPTION
netgen is taking ages to run on my design and I notice it is being built
without any optimisation. A quick test on ppc64le Linux shows -O2 is
almost twice as fast. x86-64 may not gain as much, but it will almost
certainly improve too.