### PR TITLE
Speed up extract_antenna_violators.py

### DIFF
--- a/scripts/extract_antenna_violators.py
+++ b/scripts/extract_antenna_violators.py
@@ -28,33 +28,25 @@ args = parser.parse_args()
 report_file_name = args.report
 out_file_name = args.output
 
+pattern = re.compile(r'\s*([\S+]+)\s*\([\S+]+\)\s*[\S+]+')
+
 vios_list=[]
+current_net = ''
+printed = False
 
-reportFileOpener = open(report_file_name, "r")
-if reportFileOpener.mode == 'r':
-    reportContent = reportFileOpener.read()
-reportFileOpener.close()
+with open(report_file_name, "r") as f:
+    for line in f:
+        m = pattern.match(line)
+        if m:
+            current_net = m.group(1)
+            printed = False
+
+        if '*' in line and not printed:
+            print(current_net)
+            vios_list.append(current_net + ' ')
+            printed = True
 
 
-pattern = re.compile(r'\n\s*[\S+]+\s*\([\S+]+\)\s*[\S+]+')
-cells = re.findall(pattern, reportContent)
-cnt = 0
-for idx in range(len(cells)):
-    cell = ""
-    if idx != len(cells)-1:
-        cell = reportContent.split(cells[idx])[1].split(cells[idx+1])[0]
-    else:
-        cell = reportContent.split(cells[idx])[1]
-    if cell.find("*") != -1:
-        #print("AYe")
-        #print(cells[idx])
-        #print (cells[idx+1])
-        #cnt+=1
-        vio = cells[idx].strip().split(" (")[0]
-        print(vio)     
-        vios_list.append(vio)
-    #if cnt == 7:
-        #break
 outFileOpener = open(out_file_name, "w")
 outFileOpener.write(" ".join(vios_list))
 outFileOpener.close()


### PR DESCRIPTION
extract_antenna_violators.py is doing expensive splits across the
entire file which requires large mallocs and memcpys. It also
reads the entire file in before parsing it.

Replace this with a simpler and faster way of achieving the same
thing. On my test case the time goes from over 12 minutes to 0.62
seconds, about 1200x faster.