### PR TITLE
fix missing efabless

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Alternatively, you can use the auto-built openlane docker images available throu
 Issue the following command to open the docker container from /path/to/openlane to ensure that the output files persist after exiting the container:
 
 ```bash
-    docker run -it -v $(pwd):/openLANE_flow -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -u $(id -u $USER):$(id -g $USER) openlane:rc6
+    docker run -it -v $(pwd):/openLANE_flow -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -u $(id -u $USER):$(id -g $USER) efabless/openlane:rc6
 ```
 
 ### Running the Pulled Auto-Built Docker Image


### PR DESCRIPTION
the start command doesn't work (starts building another docker image) if the efabless part is missing from the tag.