### PR TITLE
Fix make pdk on existing pdk tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ $(PDK_ROOT)/skywater-pdk:
 .PHONY: skywater-pdk
 skywater-pdk: $(PDK_ROOT)/skywater-pdk
 	cd $(PDK_ROOT)/skywater-pdk && \
-		git checkout master && git pull && \
+		git checkout master && \
+		git pull --no-recurse-submodules && \
 		git checkout -qf $(SKYWATER_COMMIT)
 
 .PHONY: skywater-library


### PR DESCRIPTION
If make pdk is run on an existing pdk tree, we get an error:

cd /home/anton/pdk.rc6/skywater-pdk && \
	git checkout master && git pull && \
	git checkout -qf 3d7617a1acb92ea883539bcf22a632d6361a5de4
Already on 'master'
Your branch is up to date with 'origin/master'.
Fetching submodule libraries/sky130_fd_io/latest
Could not access submodule 'third_party/make-env'
Fetching submodule libraries/sky130_fd_sc_hvl/latest
Errors during submodule fetch:
	libraries/sky130_fd_io/latest
make: *** [Makefile:76: skywater-pdk] Error 1

This is because we are manually checking out a subset of the submodules.
Add --no-recurse-submodules to git pull to fix this.