### PR TITLE
Avoid recursively calling generate_final_summary_report()

### DIFF
--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -238,6 +238,8 @@ proc puts_info {txt} {
 
 proc generate_final_summary_report {args} {
     if { $::env(GENERATE_FINAL_SUMMARY_REPORT) == 1 } {
+		# Avoid recursively calling generate_final_summary_report
+		set ::env(GENERATE_FINAL_SUMMARY_REPORT) 0
 		puts_info "Generating Final Summary Report..."
 		set options {
 			{-output optional}


### PR DESCRIPTION
If generate_final_summary_report() fails, we loop forever. We should
harden it against failures but for now clear GENERATE_FINAL_SUMMARY_REPORT.