### PR TITLE
Custom no synth

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -44,6 +44,8 @@ These variables are optional that can be specified in the design configuration f
 | `VERILOG_INCLUDE_DIRS` | Specifies the verilog includes directories. <br> Optional. |
 | `SYNTH_FLAT_TOP` | Specifies whether or not the top level should be flattened during elaboration. 1 = True, 0= False <br> Default=`0`. |
 | `IO_PCT` | Specifies the percentage of the clock period used in the input/output delays. Ranges from 0 to 1.0. <br> (Default: `0.2`) |
+| `NO_SYNTH_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis and timing optimizations. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells` and if it's not found, then the original liberty will be used as is. |
+
 
 ### Floorplanning
 

--- a/docs/source/OpenLANE_commands.md
+++ b/docs/source/OpenLANE_commands.md
@@ -21,7 +21,7 @@ Most of the following commands' implementation exists in this [file][0]
 |    | `[-lec]` | Runs logic verification for the new netlist against the previous netlist. <br> Optional flag.       |
 | `set_def <def>`   | | Sets the current def file used by the flow to `<def>` |
 | `prep_lefs`   | | prepares the used lef files by the flow. This process includes merging the techlef and cells lef, generated a merged.lef and a merged_unpadded.lef. Both to be used by different stages of the flow.|
-| `trim_lib`   | | prepares a liberty file (i.e. `LIB_SYNTH`) by trimming the `no_synth.cells` from another input liberty file (i.e. `$::env(LIB_SYNTH_COMPLETE)`).|
+| `trim_lib`   | | prepares a liberty file (i.e. `LIB_SYNTH`) by trimming the `NO_SYNTH_LIST` from another input liberty file (i.e. `$::env(LIB_SYNTH_COMPLETE)`). |
 |    | `[-output <lib_file>]` | The lib file to output the trimmed liberty into. <br> Default: `$::env(LIB_SYNTH)` <br> Optional flag. |
 |    | `[-input <lib_file>]` | The input liberty file to trim the cells from. <br> Default: `$::env(LIB_SYNTH_COMPLETE)` <br> Optional flag. |
 | `source_config <config_file>`   | | Sources the configurations inside `<config_file>`, whether it is a tcl file or a json file.|

--- a/docs/source/PDK_STRUCTURE.md
+++ b/docs/source/PDK_STRUCTURE.md
@@ -71,6 +71,7 @@ This section defines the necessary variables to configure a standard cell librar
 | `LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, for max delay calculation during STA. |
 | `LIB_FASTEST` | Points to the lib file, corresponding to the fastest corner, for min delay calculation during STA. |
 | `LIB_TYPICAL` | Points to the lib file for typical delay calculation during STA. |
+| `NO_SYNTH_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis and timing optimizations. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells` and if it's not found, then the original liberty will be used as is. |
 | `PLACE_SITE` | Defines the main site used by the cells. Used during floorplanning to generate the rows. |
 | `PLACE_SITE_WIDTH` | Defines the main site width.Used during floorplanning to generate the rows. |
 | `PLACE_SITE_HEIGHT` | Defines the main site height.Used during floorplanning to generate the rows. |
@@ -120,3 +121,5 @@ There are some cell types that you don't want to use in synthesis like, for exam
 Also, some of the cells, back when this list was created, had hard-to-access pin shapes, so the detailed router didn't manage to do routing cleanly.
 
 However, this list is likely over-constraining, and if you have done experiments allowing smaller sizes incrementally and still got clean routed layouts, please let us know your findings, or better yet, submit a pull request at [open_pdks](https://github.com/RTimothyEdwards/open_pdks) with a suggested no_synth list.
+
+You can also point your custom no_synth.cells by setting the value for `NO_SYNTH_LIST` to point to it.

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -112,9 +112,12 @@ proc trim_lib {args} {
     set_if_unset arg_values(-input) $::env(LIB_SYNTH_COMPLETE)
     set_if_unset arg_values(-output) $::env(LIB_SYNTH)
 
-    set scl_no_synth_lib $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells
-    if { [file exists $scl_no_synth_lib] } {
-        try_catch $::env(SCRIPTS_DIR)/libtrim.pl $arg_values(-input) $scl_no_synth_lib > $arg_values(-output)
+    # For backward compatibility
+    if {![info exists ::env(NO_SYNTH_LIST)]} {
+        set ::env(NO_SYNTH_LIST) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells
+    }
+    if { [file exists $::env(NO_SYNTH_LIST)] } {
+        try_catch $::env(SCRIPTS_DIR)/libtrim.pl $arg_values(-input) $::env(NO_SYNTH_LIST) > $arg_values(-output)
     } else {
         file copy -force $arg_values(-input) $arg_values(-output)
     }

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -117,6 +117,7 @@ proc trim_lib {args} {
         set ::env(NO_SYNTH_LIST) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells
     }
     if { [file exists $::env(NO_SYNTH_LIST)] } {
+        file copy -force $::env(NO_SYNTH_LIST) $::env(TMP_DIR)/no_synth.cells
         try_catch $::env(SCRIPTS_DIR)/libtrim.pl $arg_values(-input) $::env(NO_SYNTH_LIST) > $arg_values(-output)
     } else {
         file copy -force $arg_values(-input) $arg_values(-output)


### PR DESCRIPTION
- Utilize the future existence of NO_SYNTH_LIST variable in the pdk configs.
- Backward Compatible.
- Copy NO_SYNTH_LIST into run directory.
- Update documentation.