### PR TITLE
Magic GDS creation timestamps forced to 0

### DIFF
--- a/scripts/magic/mag_gds.tcl
+++ b/scripts/magic/mag_gds.tcl
@@ -92,6 +92,8 @@ if { $::env(MAGIC_GENERATE_GDS) } {
 		cif *array write disable
 	}
 
+	gds nodatestamp yes
+
 	gds write $::env(magic_result_file_tag).gds
 	puts "\[INFO\]: GDS Write Complete"
 }


### PR DESCRIPTION
This is useful when committing GDS files to git repos as well as diffing GDS files, etc....