### PR TITLE
Don't use no_synth cells in wire repair

### DIFF
--- a/scripts/openroad/or_wireLengthRepair.tcl
+++ b/scripts/openroad/or_wireLengthRepair.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-foreach lib $::env(LIB_SYNTH_COMPLETE) {
+foreach lib $::env(LIB_OPT) {
     read_liberty $lib
 }
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {


### PR DESCRIPTION
Wire repair is using some strange cells for buffers, eg
sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1. Avoid
this by using the trimmed library.