### PR TITLE
[CID] fix the quit on no change logic

### DIFF
--- a/.travisCI/travisUpdatePDK.sh
+++ b/.travisCI/travisUpdatePDK.sh
@@ -14,11 +14,10 @@
 # limitations under the License.
 set -e
 exit_on_no_update=0
-if [[ $TRAVIS_EVENT_TYPE ]]; then
-  if [[ $TRAVIS_EVENT_TYPE == "api" || $TRAVIS_EVENT_TYPE == "cron" ]]; then
-    exit_on_no_update=1
-  fi
+if [[ "$TRAVIS_EVENT_TYPE" == "api" || "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  exit_on_no_update=1
 fi
+
 echo "Checking the PDK version against latest pdk..."
 echo "RUN ROOT: $RUN_ROOT"
 makefile=$RUN_ROOT/Makefile

--- a/.travisCI/travisUpdateTool.sh
+++ b/.travisCI/travisUpdateTool.sh
@@ -14,11 +14,10 @@
 # limitations under the License.
 set -e
 exit_on_no_update=0
-if [[ $TRAVIS_EVENT_TYPE ]]; then
-  if [[ $TRAVIS_EVENT_TYPE == "api" || $TRAVIS_EVENT_TYPE == "cron" ]]; then
-    exit_on_no_update=1
-  fi
+if [[ "$TRAVIS_EVENT_TYPE" == "api" || "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  exit_on_no_update=1
 fi
+
 echo "Checking the tool version against latest tool..."
 echo "RUN ROOT: $RUN_ROOT"
 echo "TOOL: $TOOL"


### PR DESCRIPTION
This change got lost somewhere during the move from develop-restructure to master. So now if the job is in a cron or an api trigger, it will quit on no changes for the tool or the pdk.

This is why we have a netgen PR without a Dockerfile change.