### PR TITLE
Use optimize mirroring in detailed placement

### DIFF
--- a/scripts/openroad/or_cts.tcl
+++ b/scripts/openroad/or_cts.tcl
@@ -64,6 +64,7 @@ set buffers "$::env(CTS_ROOT_BUFFER) $::env(CTS_CLK_BUFFER_LIST)"
 set_placement_padding -masters $buffers -left $::env(CELL_PAD)
 puts "\[INFO\]: Legalizing..."
 detailed_placement -diamond_search_height $::env(PL_DIAMOND_SEARCH_HEIGHT)
+optimize_mirroring
 write_def $::env(SAVE_DEF)
 if { [check_placement -verbose] } {
 	exit 1

--- a/scripts/openroad/or_diodes.tcl
+++ b/scripts/openroad/or_diodes.tcl
@@ -89,6 +89,7 @@ puts "\n\[INFO\]: $count of $::antenna_cell_name inserted!"
 set_placement_padding -masters $::env(DIODE_CELL) -left $::env(DIODE_PADDING)
 puts "\[INFO\]: Legalizing..."
 detailed_placement  -diamond_search_height $::env(PL_DIAMOND_SEARCH_HEIGHT)
+optimize_mirroring
 write_def $::env(SAVE_DEF)
 if { [check_placement -verbose] } {
 	exit 1

--- a/scripts/openroad/or_opendp.tcl
+++ b/scripts/openroad/or_opendp.tcl
@@ -28,6 +28,8 @@ set_placement_padding -masters $::env(CELL_PAD_EXCLUDE) -right 0 -left 0
 
 detailed_placement -diamond_search_height $::env(PL_DIAMOND_SEARCH_HEIGHT)
 
+optimize_mirroring
+
 if { [check_placement -verbose] } {
 	exit 1
 }

--- a/scripts/openroad/or_resizer_timing.tcl
+++ b/scripts/openroad/or_resizer_timing.tcl
@@ -42,6 +42,7 @@ set_placement_padding -global -right $::env(CELL_PAD)
 
 set_placement_padding -masters $::env(CELL_PAD_EXCLUDE) -right 0 -left 0
 detailed_placement
+optimize_mirroring
 check_placement -verbose
 
 write_def $::env(SAVE_DEF)


### PR DESCRIPTION
This lets opendp try to reduce the wire length by mirroring cells around the X and Y axes.