### PR TITLE
Tell resizer to buffer inputs and outputs

### DIFF
--- a/scripts/openroad/or_resizer.tcl
+++ b/scripts/openroad/or_resizer.tcl
@@ -24,6 +24,9 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     puts stderr $errmsg
     exit 1
 }
+
+read_sdc -echo $::env(BASE_SDC_FILE)
+
 # Resize
 # estimate wire rc parasitics
 set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
@@ -32,6 +35,8 @@ estimate_parasitics -placement
 if { [info exists ::env(DONT_USE_CELLS)] } {
     set_dont_use $::env(DONT_USE_CELLS)
 }
+
+buffer_ports
 
 if { [info exists ::env(PL_RESIZER_MAX_WIRE_LENGTH)] && $::env(PL_RESIZER_MAX_WIRE_LENGTH) } {
     repair_design -max_wire_length $::env(PL_RESIZER_MAX_WIRE_LENGTH)


### PR DESCRIPTION
When investigating a timing issue, I noticed a huge amount of delay on
an input. Using AES as an example:

```
Fanout     Cap    Slew   Delay    Time   Description
-----------------------------------------------------------------------------
                  0.00    0.00    0.00   clock clk (rise edge)
                          0.00    0.00   clock network delay (ideal)
                          5.18    5.18 ^ input external delay
                 19.80   14.14   19.32 ^ reset_n (in)
  2739    8.94                           reset_n (net)
                 19.80    0.00   19.32 ^ _35376_/RESET_B (sky130_fd_sc_hd__dfrtp_4)
                                 19.32   data arrival time
```

Enabling input buffering fixes this, and the design makes timing.