### PR TITLE
Allow for enabling or disabling PDN check for unconnected nodes

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -78,6 +78,7 @@ These variables are optional that can be specified in the design configuration f
 | `RIGHT_MARGIN_MULT`      | The core margin, in multiples of site widths, from the right boundary.   <br> (Default: `12`) |
 | `FP_PDN_CORE_RING` | Enables adding a core ring around the design. More details on the control variables in the pdk configurations documentation. 0=Disable 1=Enable. <br> (Default: `0`) |
 | `FP_PDN_ENABLE_RAILS` | Enables the creation of rails in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
+| `FP_PDN_CHECK_NODES` | Enables checking for unconnected nodes in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_HORIZONTAL_HALO` | Sets the horizontal halo around the tap and decap cells. The value provided is in microns. <br> Default: `10` |
 | `FP_VERTICAL_HALO` | Sets the vertical halo around the tap and decap cells. The value provided is in microns. <br> Default: set to the value of `FP_HORIZONTAL_HALO` |
 | `DESIGN_IS_CORE` | Controls the layers used in the power grid. Depending on whether the design is the core of the chip or a macro inside the core. 1=Is a Core, 0=Is a Macro <br> (Default: `1`)|

--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -31,6 +31,8 @@ set ::env(FP_PDN_AUTO_ADJUST) 1
 set ::env(FP_PDN_CORE_RING) 0
 set ::env(FP_PDN_ENABLE_RAILS) 1
 
+set ::env(FP_PDN_CHECK_NODES) 1
+
 set ::env(FP_IO_MODE) 1; # 0 matching mode - 1 random equidistant mode
 set ::env(FP_IO_HLENGTH) 4
 set ::env(FP_IO_VLENGTH) 4

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -33,7 +33,9 @@ if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
 }
 
 # checks for unconnected nodes (e.g., isolated rails or stripes)
-check_power_grid -net $::env(VDD_NET)
-check_power_grid -net $::env(GND_NET)
+if { $::env(FP_PDN_CHECK_NODES) } {
+    check_power_grid -net $::env(VDD_NET)
+    check_power_grid -net $::env(GND_NET)
+}
 
 write_def $::env(SAVE_DEF)


### PR DESCRIPTION
This is useful for large designs for which the check takes a very long time. 