### PR TITLE
Makefile Clones Latest OpenMPW2 Docker Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ SPECIAL_VOLTAGE_LIBRARY ?= sky130_fd_sc_hvl
 IO_LIBRARY ?= sky130_fd_io
 INSTALL_SRAM ?= disabled
 
-IMAGE_NAME ?= efabless/openlane:current
+IMAGE_NAME ?= efabless/openlane:v0.22
 TEST_DESIGN ?= spm
 BENCHMARK ?= regression_results/benchmark_results/SW_HD.csv
 REGRESSION_TAG ?= TEST_SW_HD

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-      ___   ____   ___  ____   _       ____  ____     ___
-     /   \ |    \ /  _]|    \ | |     /    ||    \   /  _]
-    |     ||  o  )  [_ |  _  || |    |  o  ||  _  | /  [_
-    |  O  ||   _/    _]|  |  || |___ |     ||  |  ||    _]
-    |     ||  | |   [_ |  |  ||     ||  _  ||  |  ||   [_
-     \___/ |__| |_____||__|__||_____||__|__||__|__||_____|
+### Migration Notice
+
+This is a time-frozen version of OpenLane intended for use with OpenMPW 2.
+
+For a later version with more features and bugfixes, visit https://github.com/The-OpenROAD-Projects/OpenLane.
+
+---
 
 # OpenLANE
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fefabless%2Fopenlane.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fefabless%2Fopenlane?ref=badge_shield) [![Documentation Status](https://readthedocs.org/projects/openlane/badge/?version=master)](https://openlane.readthedocs.io/en/master/?badge=master) ![CI](https://github.com/efabless/openlane/workflows/CI/badge.svg?branch=main)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This documentation is also available at ReadTheDocs [here](https://openlane.readthedocs.io/).
 


### PR DESCRIPTION
We've had far too many issues with people not reading the Readme, realizing IMAGE_NAME clones the latest Docker container,  then creating a frankenstein which does not, in fact, work. There were mitigations for this applied in relation to The-OpenROAD-Project#533, but it's not enough. 

This fixes the Makefile so it pulls the latest version compatible with this fork (v0.22), and adds a pointer to upstream in the Readme.